### PR TITLE
(invoke-build) Support for powershell 4 and below

### DIFF
--- a/invoke-build/tools/chocolateyInstall.ps1
+++ b/invoke-build/tools/chocolateyInstall.ps1
@@ -2,15 +2,16 @@
 $moduleName = 'InvokeBuild'
 
 Write-Host "Installing module $moduleName to $Env:ProgramFiles\WindowsPowerShell\Modules"
-$dstDirectory = "$Env:ProgramFiles\WindowsPowerShell\Modules\$moduleName\"
+$destination = "$Env:ProgramFiles\WindowsPowerShell\Modules\$moduleName\"
 if ($PSVersionTable.PSVersion.Major -lt 5)
 {
-    $srcDirectory = "$toolsDir\$moduleName\*\*"
+    $source = "$toolsDir\$moduleName\*\*"
 } else {
-    $srcDirectory = "$toolsDir\$moduleName\*"
+    $source = "$toolsDir\$moduleName\*"
 }
 
-if (-not (Test-Path $dstDirectory)) {
-    mkdir $dstDirectory | Out-Null
+# Copy-Item results differ depending on if destination exists or not
+if (-not (Test-Path $destination)) {
+    mkdir $destination | Out-Null
 }
-cp $srcDirectory $dstDirectory -Force -Recurse
+cp $source $destination -Force -Recurse

--- a/invoke-build/tools/chocolateyInstall.ps1
+++ b/invoke-build/tools/chocolateyInstall.ps1
@@ -2,4 +2,11 @@
 $moduleName = 'InvokeBuild'
 
 Write-Host "Installing module $moduleName to $Env:ProgramFiles\WindowsPowerShell\Modules"
-cp $toolsDir\$moduleName $Env:ProgramFiles\WindowsPowerShell\Modules -Force -Recurse
+if ($PSVersionTable.PSVersion.Major -lt 5)
+{
+    $srcDirectory = "$toolsDir\$moduleName\*\"
+} else {
+    $srcDirectory = "$toolsDir\$moduleName"
+}
+
+cp $srcDirectory $Env:ProgramFiles\WindowsPowerShell\Modules\$moduleName -Force -Recurse

--- a/invoke-build/tools/chocolateyInstall.ps1
+++ b/invoke-build/tools/chocolateyInstall.ps1
@@ -2,11 +2,15 @@
 $moduleName = 'InvokeBuild'
 
 Write-Host "Installing module $moduleName to $Env:ProgramFiles\WindowsPowerShell\Modules"
+$dstDirectory = "$Env:ProgramFiles\WindowsPowerShell\Modules\$moduleName\"
 if ($PSVersionTable.PSVersion.Major -lt 5)
 {
-    $srcDirectory = "$toolsDir\$moduleName\*\"
+    $srcDirectory = "$toolsDir\$moduleName\*\*"
 } else {
-    $srcDirectory = "$toolsDir\$moduleName"
+    $srcDirectory = "$toolsDir\$moduleName\*"
 }
 
-cp $srcDirectory $Env:ProgramFiles\WindowsPowerShell\Modules\$moduleName -Force -Recurse
+if (-not (Test-Path $dstDirectory)) {
+    mkdir $dstDirectory | Out-Null
+}
+cp $srcDirectory $dstDirectory -Force -Recurse


### PR DESCRIPTION
see issue #56 

# Testing

Tested chocolateyInstall.ps1 in powershell 2
module installed at:
`C:\Program Files\WindowsPowerShell\Modules\InvokeBuild\`
Tested in powershell 5.1 and module was installed at:
`C:\Program Files\WindowsPowerShell\Modules\InvokeBuild\3.6.4\`