### PR TITLE
Fix upgrade path for cpu-z.portable

### DIFF
--- a/cpu-z.portable/tools/chocolateyInstall.ps1
+++ b/cpu-z.portable/tools/chocolateyInstall.ps1
@@ -21,10 +21,10 @@ $packageArgs = @{
 
 Install-ChocolateyZipPackage @packageArgs
 if (Get-ProcessorBits 64) {
-    rm $toolsPath\cpuz_x32.exe
-    mv $toolsPath\cpuz_x64.exe $toolsPath\cpuz.exe
+    Remove-Item $toolsPath\cpuz_x32.exe
+    Move-Item -force $toolsPath\cpuz_x64.exe $toolsPath\cpuz.exe
 } else {
-    rm $toolsPath\cpuz_x64.exe
-    mv $toolsPath\cpuz_x32.exe $toolsPath\cpuz.exe
+    Remove-Item $toolsPath\cpuz_x64.exe
+    Move-Item -force $toolsPath\cpuz_x32.exe $toolsPath\cpuz.exe
 }
 Write-Host "$packageName installed to $toolsPath"


### PR DESCRIPTION
Currently when upgrading to a newer version, cpuz_x64.exe cannot be moved to cpuz.exe without the force flag due to cpuz.exe already existing.