### PR TITLE
Added custom path option to solr package

### DIFF
--- a/solr/README.md
+++ b/solr/README.md
@@ -33,4 +33,4 @@ See more at [features page](https://lucene.apache.org/solr/features.html)
 
 ## Package Parameters
 
-- `/Path` - Install/unpack to a custom location. Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/path` parameter again.
+- `/InstallDir` - Install/unpack to a custom location. Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/InstallDir` parameter again.

--- a/solr/README.md
+++ b/solr/README.md
@@ -30,3 +30,11 @@ Solr is a standalone enterprise search server with a REST-like API. You put docu
 - Multiple search indices
 
 See more at [features page](https://lucene.apache.org/solr/features.html)
+
+### Package Parameters
+
+This package now supports the ability to install/unpack to a custom location.  Use the package parameter `/path` as in this example (try to not use paths with spaces):
+
+`choco install solr --params '"/path:c:\Solr"'
+
+**Note:** Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/path` parameter again.

--- a/solr/README.md
+++ b/solr/README.md
@@ -31,10 +31,6 @@ Solr is a standalone enterprise search server with a REST-like API. You put docu
 
 See more at [features page](https://lucene.apache.org/solr/features.html)
 
-### Package Parameters
+## Package Parameters
 
-This package now supports the ability to install/unpack to a custom location.  Use the package parameter `/path` as in this example (try to not use paths with spaces):
-
-`choco install solr --params '"/path:c:\Solr"'
-
-**Note:** Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/path` parameter again.
+- `/Path` - Install/unpack to a custom location. Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/path` parameter again.

--- a/solr/solr.nuspec
+++ b/solr/solr.nuspec
@@ -39,13 +39,11 @@
 
 See more at [features page](https://lucene.apache.org/solr/features.html)
 
-### Package Parameters
+## Package Parameters
 
-This package now supports the ability to install/unpack to a custom location.  Use the package parameter `/path` as in this example (try to not use paths with spaces):
+This package now supports the ability to install/unpack to a custom location.  Use the package parameter `/path` as in this example :
 
-`choco install solr --params '"/path:c:\Solr"'
-
-**Note:** Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/path` parameter again.
+- `/Path` - Install/unpack to a custom location. Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/path` parameter again.
 ]]></description>
     <projectUrl>https://lucene.apache.org/solr/</projectUrl>
     <tags>admin indexing search cross-platfrom</tags>

--- a/solr/solr.nuspec
+++ b/solr/solr.nuspec
@@ -41,8 +41,6 @@ See more at [features page](https://lucene.apache.org/solr/features.html)
 
 ## Package Parameters
 
-This package now supports the ability to install/unpack to a custom location.  Use the package parameter `/path` as in this example :
-
 - `/Path` - Install/unpack to a custom location. Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/path` parameter again.
 ]]></description>
     <projectUrl>https://lucene.apache.org/solr/</projectUrl>

--- a/solr/solr.nuspec
+++ b/solr/solr.nuspec
@@ -38,6 +38,14 @@
 - Multiple search indices
 
 See more at [features page](https://lucene.apache.org/solr/features.html)
+
+### Package Parameters
+
+This package now supports the ability to install/unpack to a custom location.  Use the package parameter `/path` as in this example (try to not use paths with spaces):
+
+`choco install solr --params '"/path:c:\Solr"'
+
+**Note:** Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/path` parameter again.
 ]]></description>
     <projectUrl>https://lucene.apache.org/solr/</projectUrl>
     <tags>admin indexing search cross-platfrom</tags>

--- a/solr/solr.nuspec
+++ b/solr/solr.nuspec
@@ -41,7 +41,7 @@ See more at [features page](https://lucene.apache.org/solr/features.html)
 
 ## Package Parameters
 
-- `/Path` - Install/unpack to a custom location. Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/path` parameter again.
+- `/InstallDir` - Install/unpack to a custom location. Chocolatey will **NOT** remove any files from this custom location on uninstall of the package.  Nor will it upgrade files in this custom location without using the `/InstallDir` parameter again.
 ]]></description>
     <projectUrl>https://lucene.apache.org/solr/</projectUrl>
     <tags>admin indexing search cross-platfrom</tags>

--- a/solr/tools/chocolateyinstall.ps1
+++ b/solr/tools/chocolateyinstall.ps1
@@ -2,11 +2,27 @@ $ErrorActionPreference = 'Stop'
 
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
+$pp = Get-PackageParameters
+if ($pp['path']) {
+   # make sure the path string is valid
+   $null = [system.io.fileinfo]($pp['path'])
+   Write-Host "Solr will be unpacked to the custom location, '$($pp['path'])'."
+   Write-Warning 'Custom locations are not identified or cleared on Chocolatey package upgrade or uninstall.'
+   if (-not (Test-Path $pp['path'])) {
+      Write-Host "Creating destination directory, '$($pp['path'])'"
+      $null = New-Item -Path $pp['path'] -ItemType Directory
+   }
+   $UnzipPath = $pp['path']
+} else {
+   $UnzipPath = Get-ToolsLocation
+   Write-Host "Solr will be unpacked to the default location, '$UnzipPath'."
+}
+
 $packageArgs = @{
     PackageName  = 'solr'
-    FileFullPath = gi $toolsPath\*.zip  
-    Destination  = Get-ToolsLocation
+    FileFullPath = Get-Item $toolsPath\*.zip  
+    Destination  = $UnzipPath
 }
 
 Get-ChocolateyUnzip @packageArgs
-rm $toolsPath\*.zip -ea 0
+Remove-Item $toolsPath\*.zip -ea 0

--- a/solr/tools/chocolateyinstall.ps1
+++ b/solr/tools/chocolateyinstall.ps1
@@ -3,19 +3,15 @@ $ErrorActionPreference = 'Stop'
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $pp = Get-PackageParameters
-if ($pp.Path) {
+if (!$pp.Path) {
+   $UnzipPath = Get-ToolsLocation
+   Write-Host "Solr will be unpacked to the default location, '$UnzipPath'."
+} else {
    # make sure the path string is valid
    $null = [system.io.fileinfo]($pp.Path)
    Write-Host "Solr will be unpacked to the custom location, '$($pp.Path)'."
    Write-Warning 'Custom locations are not identified or cleared on Chocolatey package upgrade or uninstall.'
-   if (-not (Test-Path $pp.Path)) {
-      Write-Host "Creating destination directory, '$($pp.Path)'"
-      $null = New-Item -Path $pp.Path -ItemType Directory
-   }
    $UnzipPath = $pp.Path
-} else {
-   $UnzipPath = Get-ToolsLocation
-   Write-Host "Solr will be unpacked to the default location, '$UnzipPath'."
 }
 
 $packageArgs = @{

--- a/solr/tools/chocolateyinstall.ps1
+++ b/solr/tools/chocolateyinstall.ps1
@@ -3,16 +3,16 @@ $ErrorActionPreference = 'Stop'
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $pp = Get-PackageParameters
-if ($pp['path']) {
+if ($pp.Path) {
    # make sure the path string is valid
-   $null = [system.io.fileinfo]($pp['path'])
-   Write-Host "Solr will be unpacked to the custom location, '$($pp['path'])'."
+   $null = [system.io.fileinfo]($pp.Path)
+   Write-Host "Solr will be unpacked to the custom location, '$($pp.Path)'."
    Write-Warning 'Custom locations are not identified or cleared on Chocolatey package upgrade or uninstall.'
-   if (-not (Test-Path $pp['path'])) {
-      Write-Host "Creating destination directory, '$($pp['path'])'"
-      $null = New-Item -Path $pp['path'] -ItemType Directory
+   if (-not (Test-Path $pp.Path)) {
+      Write-Host "Creating destination directory, '$($pp.Path)'"
+      $null = New-Item -Path $pp.Path -ItemType Directory
    }
-   $UnzipPath = $pp['path']
+   $UnzipPath = $pp.Path
 } else {
    $UnzipPath = Get-ToolsLocation
    Write-Host "Solr will be unpacked to the default location, '$UnzipPath'."


### PR DESCRIPTION
It seems that folks would like a custom install (well, unzip) location for Solr.  I too encountered a need to use Solr the other day, and could not use Chocolatey to get it because of the default "install" location.  I don't know if this is a perfect solution, but having the option should make some folks happy, and for those that were happy before, the additional code changes nothing.