### PR TITLE
Fix k6 build

### DIFF
--- a/k6/k6.nuspec
+++ b/k6/k6.nuspec
@@ -6,7 +6,7 @@
     <id>k6</id>
     <title>k6</title>
     <version>0.31.1</version>
-    <authors>https://github.com/loadimpact/k6/graphs/contributors</authors>
+    <authors>https://github.com/k6io/k6/graphs/contributors</authors>
     <owners>Miodrag Milic</owners>
     <summary>A modern load testing tool for developers and testers in the DevOps era</summary>
     <description><![CDATA[
@@ -33,14 +33,14 @@ k6 is a developer centric open source load and performance regression testing to
     <projectUrl>https://k6.io</projectUrl>
     <tags>cross-platform testing devops foss cli javascript performance</tags>
     <copyright>© 2019 LOAD IMPACT. STEWARDSHIP</copyright>
-    <licenseUrl>https://github.com/loadimpact/k6/blob/master/LICENSE.md</licenseUrl>
+    <licenseUrl>https://github.com/k6io/k6/blob/master/LICENSE.md</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/majkinetor/chocolatey/master/k6/icon.png</iconUrl>
-    <releaseNotes>https://github.com/loadimpact/k6/releases/tag/v0.31.1</releaseNotes>
+    <releaseNotes>https://github.com/k6io/k6/releases/tag/v0.31.1</releaseNotes>
     <docsUrl>https://docs.k6.io/docs</docsUrl>
     <mailingListUrl>https://community.k6.io</mailingListUrl>
-    <bugTrackerUrl>https://github.com/loadimpact/k6/issues</bugTrackerUrl>
-    <projectSourceUrl>https://github.com/loadimpact/k6</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/k6io/k6/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/k6io/k6</projectSourceUrl>
     <packageSourceUrl>https://github.com/majkinetor/chocolatey/tree/master/k6</packageSourceUrl>
   </metadata>
   <files>

--- a/k6/tools/chocolateyInstall.ps1
+++ b/k6/tools/chocolateyInstall.ps1
@@ -4,8 +4,7 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
     PackageName    = 'k6'
-    FileFullPath   = gi $toolsPath\*win32.zip
-    FileFullPath64 = gi $toolsPath\*win64.zip
+    FileFullPath64 = gi $toolsPath\*windows-amd64.zip
     Destination    = $toolsPath
 }
 Get-ChocolateyUnzip @packageArgs

--- a/k6/update.ps1
+++ b/k6/update.ps1
@@ -10,9 +10,7 @@ function global:au_SearchReplace {
         }
 
         ".\legal\VERIFICATION.txt" = @{
-          "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
           "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
-          "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
           "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
         }
     }
@@ -23,15 +21,14 @@ function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-    $re    = 'win\d\d\.zip$'
-    $url   = $download_page.links | ? href -match $re | select -First 2 -expand href | % { 'https://github.com' + $_}
+    $re    = 'windows-amd64.zip$'
+    $url   = $download_page.links | ? href -match $re | select -First 1 -expand href | % { 'https://github.com' + $_}
 
     $version  = $url -split '/' | select -Last 1 -Skip 1
 
     @{
         Version      = $version.Substring(1)
-        URL32        = $url -match 'win32' | select -First 1
-        URL64        = $url -match 'win64' | select -First 1
+        URL64        = $url
         ReleaseNotes = "https://github.com/k6io/k6/releases/tag/${version}"
     }
 }

--- a/k6/update.ps1
+++ b/k6/update.ps1
@@ -1,6 +1,6 @@
 import-module au
 
-$releases = 'https://github.com/loadimpact/k6/releases'
+$releases = 'https://github.com/k6io/k6/releases'
 
 function global:au_SearchReplace {
    @{
@@ -32,7 +32,7 @@ function global:au_GetLatest {
         Version      = $version.Substring(1)
         URL32        = $url -match 'win32' | select -First 1
         URL64        = $url -match 'win64' | select -First 1
-        ReleaseNotes = "https://github.com/loadimpact/k6/releases/tag/${version}"
+        ReleaseNotes = "https://github.com/k6io/k6/releases/tag/${version}"
     }
 }
 


### PR DESCRIPTION
Hi, we recently did some release changes in k6 that broke the creation of the Chocolatey package. According to the CircleCI builds it's not detecting a new version even though [v0.32.0 was released a week ago](https://github.com/k6io/k6/releases/tag/v0.32.0).

I did some changes here that should hopefully fix that, but I'm not familiar with your setup and haven't tested this so feel free to adjust it.

As discussed previously we'll contact you sometime in the next few weeks to discuss us taking over the maintenance of the package, though in the immediate term it would be good to have this fixed and the existing package updated.

Thanks!