### PR TITLE
Allow packaging of betas

### DIFF
--- a/signal/update.ps1
+++ b/signal/update.ps1
@@ -16,7 +16,7 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $version = $download_page.links.href -match 'tag/v' -notmatch 'beta' | Select -First 1 | % { $_ -split '/' | select -Last 1 }
+    $version = $download_page.links.href -match 'tag/v' | Select -First 1 | % { $_ -split '/' | select -Last 1 }
     $version = $version.Substring(1)
     @{
         Version      = $version


### PR DESCRIPTION
Remove `-notmatch 'beta'` since Signal project uses semver; this will allow beta versions to show up as installable on chocolatey with `--prerelease` functionality.