### PR TITLE
chore: Bump git dependency to 2.34.1

### DIFF
--- a/gitlab-runner/gitlab-runner.nuspec
+++ b/gitlab-runner/gitlab-runner.nuspec
@@ -56,8 +56,8 @@
     <projectSourceUrl>https://gitlab.com/gitlab-org/gitlab-ci-multi-runner/tree/master</projectSourceUrl>
     <packageSourceUrl>https://github.com/majkinetor/chocolatey/tree/master/gitlab-runner</packageSourceUrl>
     <dependencies>
-      <dependency id="chocolatey-core.extension" version="1.3.1" />
-      <dependency id="git.install" version="2.12.2" />
+      <dependency id="chocolatey-core.extension" version="1.3.5.1" />
+      <dependency id="git.install" version="2.34.1" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Also bump chocolatey-core.extension dependency to 1.3.5.1

Fixes #203