### PR TITLE
(maint) Update nuspec instructions

### DIFF
--- a/postgresql/postgresql.nuspec
+++ b/postgresql/postgresql.nuspec
@@ -58,8 +58,8 @@ Each major version has its own package: `postgresql<Version>`
 To propagate package parameters to dependencies use `--params-global` choco install parameter with virtual package `postgresql`. Assuming latest version is 12, to provide password the following two examples result in identical installation:
 
 ```
-cinst postgresql --params '/Password:test' --params-global
-cinst postgresql12 --params '/Password:test'
+choco install postgresql --params '/Password:test' --params-global
+choco install postgresql12 --params '/Password:test'
 ```
 
 To uninstall dependent package use `--force-dependencies`:
@@ -77,14 +77,14 @@ To force reinstallation via virtual package use `--force-dependencies`:
 
 ```
 # The following two examples are identical
-cinst postgresql --force --force-dependencies
-cinst postgresql12 --force --force-dependencies
+choco install postgresql --force --force-dependencies
+choco install postgresql12 --force --force-dependencies
 
 # This will reinstall only postgresql virtual package and not its dependency postgresql12
-cinst postgresql -force
+choco install postgresql -force
 
 # This one is different then the first one as vcredist140 dependency is not reinstalled
-cinst postgresql12 --force
+choco install postgresql12 --force
 ```
 ]]></description>
     <summary>PostgreSQL is an object-relational database management system</summary>


### PR DESCRIPTION
To use `choco install` rather than `cinst`.

In the upcoming version of Chocolatey CLI, the cinst shim is no longer going to be available.