### PR TITLE
Update README.md

### DIFF
--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -48,31 +48,31 @@ Each major version has its own package: `postgresql<Version>`
 To propagate package parameters to dependencies use `--params-global` choco install parameter with virtual package `postgresql`. Assuming latest version is 12, to provide password the following two examples result in identical installation:
 
 ```
-cinst postgresql --params '/Password:test' --params-global
-cinst postgresql12 --params '/Password:test'
+choco install postgresql --params '/Password:test' --params-global
+choco install postgresql12 --params '/Password:test'
 ```
 
 To uninstall dependent package use `--force-dependencies`:
 
 ```
 # The following two examples are identical
-cuninst postgresql --force-dependencies
-cuninst postgresql12 postgresql
+choco uninstall postgresql --force-dependencies
+choco uninstall postgresql12 postgresql
 
 # This example uninstalls only postgresql virtual package and not postgresql12
-cuninst postgresql
+choco uninstall postgresql
 ```
 
 To force reinstallation via virtual package use `--force-dependencies`:
 
 ```
 # The following two examples are identical
-cinst postgresql --force --force-dependencies
-cinst postgresql12 --force --force-dependencies
+choco install postgresql --force --force-dependencies
+choco install postgresql12 --force --force-dependencies
 
 # This will reinstall only postgresql virtual package and not its dependency postgresql12
-cinst postgresql -force
+choco install postgresql -force
 
 # This one is different then the first one as vcredist140 dependency is not reinstalled
-cinst postgresql12 --force
+choco install postgresql12 --force
 ```


### PR DESCRIPTION
To remove mention of obsolete choco shims.

cinst and cuninst no longer ship as part of Chocolatey CLI.