### PR TITLE
(maint) Don't use removed shims

### DIFF
--- a/rundeck/rundeck.nuspec
+++ b/rundeck/rundeck.nuspec
@@ -56,7 +56,7 @@ $params = [ordered]@{
     TimeZone        = 'Europe/Belgrade'
 }
 $params = $params.GetEnumerator() | % { if ($_.Value -is [bool]) { if ($_.Value) { "/{0}" -f $_.Key}} else { "/{0}:'{1}'" -f $_.Key, $_.Value } }
-cinst rundeck --params $params
+choco install rundeck --params $params
 ```
 
 ## Notes


### PR DESCRIPTION
Starting with Chocolatey CLI 2.0.0, the cinst shim (along with others) are no longer in place, and the suggestion is to always use the full Chocolatey CLI command.

I noticed that the cinst shim was being used in a recent package moderation.